### PR TITLE
Updated API address to match current scheme from pixelcanvas.io

### DIFF
--- a/pixelcanvas.py
+++ b/pixelcanvas.py
@@ -154,7 +154,7 @@ def insert_chunks(chunks, commit=True):
 # API FUNCTIONS
 ################################################################################
 def url_for_bigchunk(bigchunk_x, bigchunk_y):
-    return f'http://api.pixelcanvas.io/api/bigchunk/{bigchunk_x}.{bigchunk_y}.bmp'
+    return f'http://pixelcanvas.io/api/bigchunk/{bigchunk_x}.{bigchunk_y}.bmp'
 
 def request(url):
     response = session.get(url)


### PR DESCRIPTION
From my cron messages it looks like this broke some time around the first of January 2022, I messaged the webmaster and they gave me the updated URL, it's a simple change so there's not much else to say.
I hope this is of use.